### PR TITLE
The counter was not decremented when the specified timewindow expires.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,10 @@ port = 8888
 ####Sample Output as read with netcat:
 ```
 $> nc -ul -p 8888
-{"EventOccurance":363,"EventThreshold":15,"Hostname":"SERVER1-\u003e127.0.0.1","Message":"Oct  7 10:27:00 SERVER1 sshd[1960]: Accepted password for SOMEUSER from 10.10.10.10 port 21064 ssh2","RuleID":5715,"Syslogcrit":3,"TimesAlerted":349}
-{"EventOccurance":2633,"EventThreshold":10,"Hostname":"SERVER-1-\u003e127.0.0.1","Message":"Oct  7 10:27:01 SERVER-1 CROND[24743]: pam_unix(cron:session): session opened for user root by (uid=0)","RuleID":5501,"Syslogcrit":3,"TimesAlerted":2624}
+
+{"EventOccurance":16,"EventThreshold":15,"Hostname":"myserver-\u003e127.0.0.1","Message":"Oct 13 12:59:15 myserver sshd[8918]: Failed password for invalid user a from 127.0.0.1 port 60293 ssh2","RuleID":5712,"Syslogcrit":10,"TimesAlerted":1,"TotalEventOccurance":16}
+
+
 ```
 
 Consuming script can use a modulus on ```TimesAlerted``` value to decide on the frequency of triggering alerts.

--- a/gossecer.go
+++ b/gossecer.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"github.com/nohupped/GoLogger"
-	//"github.com/nohupped/Gossecer/modules"
-	"Gossecer/modules"
+	"github.com/nohupped/Gossecer/modules"
+//	"Gossecer/modules"
 	"flag"
 	"sync"
 	"os"

--- a/gossecer.go
+++ b/gossecer.go
@@ -2,7 +2,8 @@ package main
 
 import (
 	"github.com/nohupped/GoLogger"
-	"github.com/nohupped/Gossecer/modules"
+	//"github.com/nohupped/Gossecer/modules"
+	"Gossecer/modules"
 	"flag"
 	"sync"
 	"os"

--- a/modules/SendAlert.go
+++ b/modules/SendAlert.go
@@ -4,9 +4,7 @@ import (
 	"github.com/nohupped/GoLogger"
 	"net"
 	"encoding/json"
-	"fmt"
 	"strconv"
-	"time"
 )
 
 var alertLogger *GoLogger.LogIt
@@ -24,12 +22,12 @@ func CheckCounter(counterchan chan *Jsondata, threshold []Key, alertschan chan *
 	for _, i := range lrange.Val() {
 		histime, _ := strconv.ParseInt(i, 10, 64)
 		if (Alert.CurrentEventOccurrenceTime - histime) >= Alert.TTL.Nanoseconds() {
-			fmt.Println(time.Unix(0, histime), "exceeded TTL time of", Alert.TTL.Nanoseconds(), "for", Alert.HashKey, Alert.RPush)
-			fmt.Println(redisClient.LPop(Alert.RPush)) // Poping the oldest timestamp because it expired, has to decrement COUNTER
-			fmt.Println(redisClient.HIncrBy(Alert.HashKey, "COUNTER", int64(-1))) //Decrementing the COUNTER by 1 each time.
+			//fmt.Println(time.Unix(0, histime), "exceeded TTL time of", Alert.TTL.Nanoseconds(), "for", Alert.HashKey, Alert.RPush)
+			redisClient.LPop(Alert.RPush) // Poping the oldest timestamp because it expired, has to decrement COUNTER
+			redisClient.HIncrBy(Alert.HashKey, "COUNTER", int64(-1)) //Decrementing the COUNTER by 1 each time.
 
 		} else {
-			fmt.Println("Exiting to timecheck")
+			//fmt.Println("Exiting to timecheck")
 			break ExitTimeCheck
 		}
 	}

--- a/modules/SendAlert.go
+++ b/modules/SendAlert.go
@@ -4,6 +4,9 @@ import (
 	"github.com/nohupped/GoLogger"
 	"net"
 	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
 )
 
 var alertLogger *GoLogger.LogIt
@@ -15,6 +18,13 @@ var alertLogger *GoLogger.LogIt
 func CheckCounter(counterchan chan *Jsondata, threshold []Key, alertschan chan *Jsondata)  {
 	alertLogger = GoLogger.New("/var/log/gossecer_alert.log")
 	Alert := <-counterchan
+
+	lrange := redisClient.LRange(Alert.RPush, 0, -1)
+	for _, i := range lrange.Val() {
+		histime, _ := strconv.ParseInt(i, 10, 64)
+		fmt.Println(time.Unix(0, histime))
+	}
+
 	Alert.Threshold = 15 // default value
 
 	Outer:

--- a/modules/startudpserver.go
+++ b/modules/startudpserver.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"bytes"
 	"regexp"
+	"time"
 )
 
 // Jsondata struct is used to populate from the ossec forwarded udp datagrams
@@ -17,16 +18,20 @@ import (
 type Jsondata struct {
 	Crit           int `json:"crit"`
 	Id             int `json:"id"`
-	Component      string `json:"component"`  //hostname
+	Component      string `json:"component"` //hostname
 	Classification string `json:"classification"`
-	Description    string `json:"description"`
-	Message        string `json:"message"`
-	NormalizedMessage string // normalised message
-	HashKey		string // The md5 hash value
-	Counter      	int  // The current counter taken from redis
-	Threshold 	int  // The actual threshold to be breached by counter to mark it as an alert.
-	Alerted		int64  // A counter to keep track of how many times alerts are sent.
-	TotalCount	int // A counter to keep track of the total count of alerts before it is expired in redis.
+	Description                string `json:"description"`
+	Message                    string `json:"message"`
+	NormalizedMessage          string        // normalised message
+	HashKey                    string        // The md5 hash value
+	Counter                    int           // The current counter taken from redis
+	Threshold                  int           // The actual threshold to be breached by counter to mark it as an alert.
+	Alerted                    int64         // A counter to keep track of how many times alerts are sent.
+	TotalCount                 int           // A counter to keep track of the total count of alerts before it is expired in redis.
+	CurrentEventOccurrenceTime int64         // Epoch value of current event occurrence time in nanoseconds.
+	FirstEventOccurrenceTime int64         // Epoch value of current event occurrence time in nanoseconds.
+	TTL                        time.Duration // The configured TTL for the event, which will be set as the expire for HashKey and RPush keys.
+	RPush                      string        // The rpush key that holds the list of epoch time values
 }
 
 // JsondataNormalize method will read the Message variable in the struct Jsondata, normalize it and
@@ -76,5 +81,6 @@ func handleUDP(conn *net.UDPConn) *Jsondata{
 	CheckError(err)
 //	udplogger.Info.Println(string(buffer[:n]))
 	json.Unmarshal(splitbytes[1], &jsonstring)
+	jsonstring.CurrentEventOccurrenceTime = time.Now().UnixNano()
 	return jsonstring
 }


### PR DESCRIPTION
When the specified timewindow or TTL expires, the counter was not decremented. This would result in fake alerts and spamming. Fix:  Store the timestamps as an rpush array in redis, and compare the (current event occurrence time - each of the historic times) >= ttl value. (Use epochvalue in nanoseconds for precision. )
